### PR TITLE
Fix for issue with poor text spacing in PDF

### DIFF
--- a/src/main/java/mimeparser/MimeMessageConverter.java
+++ b/src/main/java/mimeparser/MimeMessageConverter.java
@@ -83,6 +83,10 @@ public class MimeMessageConverter {
 	private static final Pattern IMG_CID_REGEX = Pattern.compile("cid:(.*?)\"", Pattern.DOTALL);
 	private static final Pattern IMG_CID_PLAIN_REGEX = Pattern.compile("\\[cid:(.*?)\\]", Pattern.DOTALL);
 
+	private static final String VIEWPORT_SIZE = "2480x3508";
+	private static final int CONVERSION_DPI = 300;
+	private static final int IMAGE_QUALITY = 100;
+
 	/**
 	 * Execute a command and redirect its output to the standard output.
 	 * @param command list of the command and its parameters
@@ -258,9 +262,10 @@ public class MimeMessageConverter {
 		Logger.debug("Write pdf to %s", pdf.getAbsolutePath());
 
 		List<String> cmd = new ArrayList<String>(Arrays.asList("wkhtmltopdf",
-				"--viewport-size", "2480x3508",
+				"--viewport-size", VIEWPORT_SIZE,
 				// "--disable-smart-shrinking",
-				"--image-quality", "100",
+				"--dpi", String.valueOf(CONVERSION_DPI),
+				"--image-quality", String.valueOf(IMAGE_QUALITY),
 				"--encoding", charsetName));
 		cmd.addAll(extParams);
 		cmd.add(tmpHtml.getAbsolutePath());


### PR DESCRIPTION
Found the issue with poor kerning when trying to convert EML to PDF on Windows with the latest tool release version. (On Linux, I did not see the issue.)
Here is [an example of initial EML](https://www.dropbox.com/s/3hqbaemqfj9ai1v/Message15125097410000000051.eml?dl=0) and here is [an example of the resulting PDF](https://www.dropbox.com/s/6h0nv63myg7ihp6/Message15125097410000000051.pdf?dl=0).

After some search, I found that it turns to be [a known issue in wkhtmltopdf](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/45). After upgrading to the recent release of wkhtmltopdf, I still could reproduce the issue. For Windows, the only working solution for that seems to be increasing conversion DPI for the tool (by default it is 96). As it should not have severe side effects, I suggest increasing conversion DPI in the command that calls wkhtmltopdf. 
I have tested the fix both on Windows and Ubuntu.