### PR TITLE
Fix error on Ubuntu Bionic with Open JDK 11.0.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
 sourceCompatibility = 1.7
 
 /* calculate version */
-ext.repo = org.ajoberstar.grgit.Grgit.open(project.file('.'))
+ext.repo = org.ajoberstar.grgit.Grgit.open(currentDir: project.rootDir)
 version = "${repo.tag.list().last().name}"
 
 jar {


### PR DESCRIPTION
I don't know why but I have to change this line of code for work on my Ubuntu Bionic setup with OpenJDK 11.0.4 installed on it. The original file caused me an exception.

FAILURE: Build failed with an exception.

* Where:
Build file '(...)/build.gradle' line: 28

* What went wrong:
A problem occurred evaluating root project 'eml-to-pdf-converter'.
> repository not found: (..)

After change it works