### PR TITLE
fixing grey header in pdf

### DIFF
--- a/src/main/java/mimeparser/MimeMessageConverter.java
+++ b/src/main/java/mimeparser/MimeMessageConverter.java
@@ -259,6 +259,7 @@ public class MimeMessageConverter {
 
 		List<String> cmd = new ArrayList<String>(Arrays.asList("wkhtmltopdf",
 				"--viewport-size", VIEWPORT_SIZE,
+				"--enable-local-file-access",
 				// "--disable-smart-shrinking",
 				"--dpi", String.valueOf(CONVERSION_DPI),
 				"--image-quality", String.valueOf(IMAGE_QUALITY),


### PR DESCRIPTION
with an update to wkhtmltopdf version 0.12.6 the behavior regarding referencing
local files changed. It was disabled by default. The grey header comes from
such a file that is generated in the temp directory and can't be included. In
order to fix the issue the command line parameter --enable-local-file-access
needs to be used when calling wkhtmltopdf.

I checked wkhtmltopdf and saw that the command line parameter was already
available since 2011. Thus I didn't add a logic to prevent it from being used
for versions prior to 0.12.6